### PR TITLE
fix: gdb extended-remote can cause target confusion

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -1,2 +1,2 @@
-target extended-remote :1234
+target remote :1234
 layout split


### PR DESCRIPTION
See https://sourceware.org/gdb/current/onlinedocs/gdb.html/Connecting.html. With target extended-remote mode: You may specify the program to debug on the gdbserver command line, or you can load the program or attach to it using GDB commands after connecting to gdbserver.

Some students reported target architecture differ from select architecture, causing GDB to fail

(cherry picked from commit e35669442875eba414e4cf5b238ef32513dda1c4)